### PR TITLE
Add bootctrl import and HIDL interface prebuilts

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -4,6 +4,26 @@
 //
 
 soong_namespace {
+    imports: [
+        "hardware/qcom-caf/bootctrl",
+        "vendor/oneplus/sm8350-common",
+    ],
+}
+
+prebuilt_hidl_interfaces {
+    name: "hidl_netperftuner_interface",
+    interfaces: [
+        "vendor.qti.hardware.wigig.netperftuner@1.0::INetPerfTuner",
+    ],
+}
+
+prebuilt_hidl_interfaces {
+    name: "hidl_vppservice_interface",
+    interfaces: [
+        "vendor.qti.hardware.vpp@1.1::IHidlVppService",
+        "vendor.qti.hardware.vpp@1.2::IHidlVppService",
+        "vendor.qti.hardware.vpp@1.3::IHidlVppService",
+    ],
 }
 
 install_symlink {


### PR DESCRIPTION
## Summary
- add missing namespace imports for bootctrl and sm8350-common
- ship prebuilt HIDL interfaces for netperftuner and vppservice

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68407cb896f08332803a71fa700f4613