### PR TITLE
Add yaap.dependencies

### DIFF
--- a/yaap.dependencies
+++ b/yaap.dependencies
@@ -1,0 +1,14 @@
+[
+  {
+    "repository": "kernel_oneplus_sm8350",
+    "target_path": "kernel/oneplus/sm8350"
+  },
+  {
+    "repository": "hardware_oneplus",
+    "target_path": "hardware/oneplus"
+  },
+  {
+    "repository": "vendor_oneplus_sm8350-common",
+    "target_path": "vendor/oneplus/sm8350-common"
+  }
+]


### PR DESCRIPTION
## Summary
- add `yaap.dependencies` with kernel, hardware and vendor entries

## Testing
- `python3 extract-files.py` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6840842e910c833291af6e844f5b32d4